### PR TITLE
Validate host/port arguments in docs server script

### DIFF
--- a/scripts/serve-docs.sh
+++ b/scripts/serve-docs.sh
@@ -36,8 +36,24 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --private) MODE="private"; shift ;;
     --public)  MODE="public";  shift ;;
-    --host)    HOST="${2:-}"; shift 2 ;;
-    --port)    PORT="${2:-}"; shift 2 ;;
+    --host)
+      if [[ $# -lt 2 || -z "$2" ]]; then
+        echo "Error: --host requires an argument" >&2
+        usage
+        exit 2
+      fi
+      HOST="$2"
+      shift 2
+      ;;
+    --port)
+      if [[ $# -lt 2 || -z "$2" ]]; then
+        echo "Error: --port requires an argument" >&2
+        usage
+        exit 2
+      fi
+      PORT="$2"
+      shift 2
+      ;;
     --strict)  STRICT=1; shift ;;
     --browse)  BROWSE=1; shift ;;
     -h|--help) usage; exit 0 ;;


### PR DESCRIPTION
## Summary
- ensure `serve-docs.sh` errors when `--host` or `--port` lack required values

## Testing
- `bash -n scripts/serve-docs.sh`
- `scripts/serve-docs.sh --host` *(fails with missing argument)*
- `scripts/serve-docs.sh --port` *(fails with missing argument)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b6a8a0f88320860628af1df1000c